### PR TITLE
Make getNumbers more unit testable

### DIFF
--- a/Rexcfnghk.MarkSixParser.Runner/UseCases.fs
+++ b/Rexcfnghk.MarkSixParser.Runner/UseCases.fs
@@ -9,9 +9,11 @@ let tryGetInteger () =
         | true, i -> ValidationResult.success i
         | false, _ -> "Input is not an integer" |> ValidationResult.errorFromString
 
-    ValidationResult.retryable (printfn "%A") (stdin.ReadLine >> validateInt32)
+    let intV = stdin.ReadLine() |> validateInt32
 
-let getDrawResultNumbers' () = MarkSix.getDrawResultNumbers (printfn "%A") tryGetInteger
+    ValidationResult.retryable (printfn "%A") intV
+
+let getDrawResultNumbers' () = MarkSix.getDrawResultNumbers (printfn "%A") (fun _ -> tryGetInteger())
 
 let getMultipleUsersDraw () =
     let rec getUsersDrawNumbers' decision acc i =
@@ -20,7 +22,7 @@ let getMultipleUsersDraw () =
         else
             let newCount = i + 1
             printfn "Enter user's #%i draw" newCount
-            let usersDraw = MarkSix.getUsersDrawNumber (printfn "%A") tryGetInteger
+            let usersDraw = MarkSix.getUsersDrawNumber (printfn "%A") (fun _ -> tryGetInteger())
             printfn "Continue entering user's draw #%i [YyNn]?" (newCount + 1)
             let decision = stdin.ReadLine()
             getUsersDrawNumbers' decision (usersDraw :: acc) newCount

--- a/Rexcfnghk.MarkSixParser.Runner/UseCases.fs
+++ b/Rexcfnghk.MarkSixParser.Runner/UseCases.fs
@@ -3,7 +3,7 @@
 open System
 open Rexcfnghk.MarkSixParser
 
-let tryGetInteger () = 
+let tryGetInteger _ = 
     let validateInt32 string =
         match Int32.TryParse string with
         | true, i -> ValidationResult.success i
@@ -13,7 +13,7 @@ let tryGetInteger () =
 
     ValidationResult.retryable (printfn "%A") intV
 
-let getDrawResultNumbers' () = MarkSix.getDrawResultNumbers (printfn "%A") (fun _ -> tryGetInteger())
+let getDrawResultNumbers' () = MarkSix.getDrawResultNumbers (printfn "%A") tryGetInteger
 
 let getMultipleUsersDraw () =
     let rec getUsersDrawNumbers' decision acc i =
@@ -22,7 +22,7 @@ let getMultipleUsersDraw () =
         else
             let newCount = i + 1
             printfn "Enter user's #%i draw" newCount
-            let usersDraw = MarkSix.getUsersDrawNumber (printfn "%A") (fun _ -> tryGetInteger())
+            let usersDraw = MarkSix.getUsersDrawNumber (printfn "%A") tryGetInteger
             printfn "Continue entering user's draw #%i [YyNn]?" (newCount + 1)
             let decision = stdin.ReadLine()
             getUsersDrawNumbers' decision (usersDraw :: acc) newCount

--- a/Rexcfnghk.MarkSixParser.Tests/Facts.fs
+++ b/Rexcfnghk.MarkSixParser.Tests/Facts.fs
@@ -88,7 +88,7 @@ let ``toDrawResults respects order of entering`` () =
 let ``getDrawResults respects order of entering`` () =
     let ints = [| 6; 7; 12; 15; 27; 36; 29 |]
 
-    let drawResults = MarkSix.getDrawResultNumbers ignore (fun i -> ints.[i])
+    let drawResults = MarkSix.getDrawResultNumbers ignore (Array.get ints)
 
     let (DrawResults (DrawnNumber m1, DrawnNumber m2, DrawnNumber m3, 
                         DrawnNumber m4, DrawnNumber m5, DrawnNumber m6, ExtraNumber e)) = drawResults
@@ -99,15 +99,13 @@ let ``getDrawResults respects order of entering`` () =
     [i1; i2; i3; i4; i5; i6; e] =! List.ofArray ints
 
 [<Fact>]
-let ``getDrawResultNumbers also passes in indices`` () =
-    let ints = [| 6; 7; 12; 15; 27; 36; 29 |]
+let ``getUsersDrawNumbers respects order of entering`` () =
+    let ints = [| 6; 7; 12; 15; 27; 36 |]
     
-    let drawResults = MarkSix.getDrawResultNumbers ignore (fun i -> ints.[i])
+    let drawResults = MarkSix.getUsersDrawNumber ignore (Array.get ints)
 
-    let (DrawResults (DrawnNumber m1, DrawnNumber m2, DrawnNumber m3, 
-                        DrawnNumber m4, DrawnNumber m5, DrawnNumber m6, ExtraNumber e)) = drawResults
-    let i1, i2, i3, i4, i5, i6, e = MarkSixNumber.value m1, MarkSixNumber.value m2, MarkSixNumber.value m3, 
-                                       MarkSixNumber.value m4, MarkSixNumber.value m5, MarkSixNumber.value m6, 
-                                       MarkSixNumber.value e
+    let (UsersDraw (m1, m2, m3, m4, m5, m6)) = drawResults
+    let i1, i2, i3, i4, i5, i6 = MarkSixNumber.value m1, MarkSixNumber.value m2, MarkSixNumber.value m3, 
+                                   MarkSixNumber.value m4, MarkSixNumber.value m5, MarkSixNumber.value m6
      
-    [i1; i2; i3; i4; i5; i6; e] =! List.ofArray ints
+    [i1; i2; i3; i4; i5; i6] =! List.ofArray ints

--- a/Rexcfnghk.MarkSixParser.Tests/Facts.fs
+++ b/Rexcfnghk.MarkSixParser.Tests/Facts.fs
@@ -101,3 +101,17 @@ let ``getDrawResults respects order of entering`` () =
                                        MarkSixNumber.value e
      
     [i1; i2; i3; i4; i5; i6; e] =! List.ofArray ints
+
+[<Fact>]
+let ``getDrawResultNumbers also passes in indices`` () =
+    let ints = [| 6; 7; 12; 15; 27; 36; 29 |]
+    
+    let drawResults = MarkSix.getDrawResultNumbers ignore (fun i -> ints.[i])
+
+    let (DrawResults (DrawnNumber m1, DrawnNumber m2, DrawnNumber m3, 
+                        DrawnNumber m4, DrawnNumber m5, DrawnNumber m6, ExtraNumber e)) = drawResults
+    let i1, i2, i3, i4, i5, i6, e = MarkSixNumber.value m1, MarkSixNumber.value m2, MarkSixNumber.value m3, 
+                                       MarkSixNumber.value m4, MarkSixNumber.value m5, MarkSixNumber.value m6, 
+                                       MarkSixNumber.value e
+     
+    [i1; i2; i3; i4; i5; i6; e] =! List.ofArray ints

--- a/Rexcfnghk.MarkSixParser.Tests/Facts.fs
+++ b/Rexcfnghk.MarkSixParser.Tests/Facts.fs
@@ -87,12 +87,8 @@ let ``toDrawResults respects order of entering`` () =
 [<Fact>]
 let ``getDrawResults respects order of entering`` () =
     let ints = [| 6; 7; 12; 15; 27; 36; 29 |]
-    let mutable i = 0
 
-    let drawResults = MarkSix.getDrawResultNumbers ignore <| fun () -> 
-        let result = ints.[i]
-        i <- i + 1
-        result
+    let drawResults = MarkSix.getDrawResultNumbers ignore (fun i -> ints.[i])
 
     let (DrawResults (DrawnNumber m1, DrawnNumber m2, DrawnNumber m3, 
                         DrawnNumber m4, DrawnNumber m5, DrawnNumber m6, ExtraNumber e)) = drawResults

--- a/Rexcfnghk.MarkSixParser/MarkSix.fs
+++ b/Rexcfnghk.MarkSixParser/MarkSix.fs
@@ -44,7 +44,7 @@ let private addUniqueToList maxCount errorHandler getNumber =
         |> ValidationResult.retryable errorHandler
 
     let rec addUniqueToListImpl i acc =
-        if i = maxCount - 1
+        if i = maxCount
         then List.rev acc
         else
             let updated = createFromGetNumber i acc

--- a/Rexcfnghk.MarkSixParser/MarkSix.fs
+++ b/Rexcfnghk.MarkSixParser/MarkSix.fs
@@ -34,23 +34,23 @@ let private addUniqueToList maxCount errorHandler getNumber =
     let addToSet acc input =
         let set = Set.ofList acc
         if Set.count set = List.length acc
-        then (input :: acc) |> ValidationResult.success
+        then input :: acc |> ValidationResult.success
         else "Adding duplicate elements" |> ValidationResult.errorFromString
 
-    let createFromGetNumber list = 
-        getNumber 
-        >> MarkSixNumber.create 
-        >=> addToSet list
+    let createFromGetNumber i list = 
+        getNumber i
+        |> MarkSixNumber.create 
+        >>= addToSet list
         |> ValidationResult.retryable errorHandler
 
-    let rec addUniqueToListImpl acc =
-        if List.length acc = maxCount
+    let rec addUniqueToListImpl i acc =
+        if i = maxCount - 1
         then List.rev acc
         else
-            let updated = createFromGetNumber acc
-            addUniqueToListImpl updated
+            let updated = createFromGetNumber i acc
+            addUniqueToListImpl (i + 1) updated
 
-    addUniqueToListImpl []
+    addUniqueToListImpl 0 []
 
 let private getNumbers errorHandler f maxCount =
     addUniqueToList maxCount errorHandler

--- a/Rexcfnghk.MarkSixParser/Validations.fs
+++ b/Rexcfnghk.MarkSixParser/Validations.fs
@@ -23,12 +23,12 @@ module ValidationResult =
         | Success x -> successHandler x
         | Error e -> errorHandler e
 
-    let rec retryable errorHandler f =
-        let result = f ()
-        let retry e =
+    let rec retryable errorHandler x =
+        match x with
+        | Success s -> s
+        | Error e -> 
             errorHandler e
-            retryable errorHandler f
-        doubleMap id retry result
+            retryable errorHandler x
 
     let map f = doubleMap (f >> Success) Error
 


### PR DESCRIPTION
This changes the `int` generator function from `unit -> int` to `int -> int`, which the parameter is the index of the current `MarkSixNumber`.

This is considered a temp fix until a proper refactoring is done.

See #24. 
